### PR TITLE
Update ffmpeg Installation Instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ GPUs will be able to generate short sequences, or longer sequences with the `sma
 **Note**: Please make sure to have [ffmpeg](https://ffmpeg.org/download.html) installed when using newer version of `torchaudio`.
 You can install it with:
 ```
-apt-get install ffmpeg
+sudo apt-get install ffmpeg
 ```
 
 See after a quick example for using the API.


### PR DESCRIPTION
Updated the ffmpeg installation command in the README file by adding `sudo` to prevent potential permission errors during setup. 

Changes:
- Added `sudo` to `apt-get install ffmpeg` in README.