### PR TITLE
Use greedy sampling path when temp is 0.0 to avoid division by zero

### DIFF
--- a/audiocraft/models/lm.py
+++ b/audiocraft/models/lm.py
@@ -363,7 +363,8 @@ class LMModel(StreamingModule):
         logits = logits.permute(0, 1, 3, 2)  # [B, K, card, T]
         logits = logits[..., -1]  # [B x K x card]
 
-        if use_sampling:
+        # Apply softmax for sampling if temp > 0. Else, do greedy sampling to avoid zero division error.
+        if use_sampling and temp > 0.0:
             probs = torch.softmax(logits / temp, dim=-1)
             if top_p > 0.0:
                 next_token = utils.sample_top_p(probs, p=top_p)


### PR DESCRIPTION
![image](https://github.com/facebookresearch/audiocraft/assets/163408/b87d0910-c493-4ae0-9114-9bbee36e339f)

Considered also changing the Gradio widget to prevent negative temp. But I just tried a few samples.... say what you like about the horrible noises you get with negative temperature sampling - at least it's an ethos. ( And it doesn't crash. )