### PR TITLE
Update musicgen.py to use cpu if cuda not available

### DIFF
--- a/audiocraft/models/musicgen.py
+++ b/audiocraft/models/musicgen.py
@@ -65,7 +65,7 @@ class MusicGen:
         return self.compression_model.channels
 
     @staticmethod
-    def get_pretrained(name: str = 'melody', device='cuda'):
+    def get_pretrained(name: str = 'melody', device=('cuda' if  torch.cuda.is_available() else 'cpu')):
         """Return pretrained model, we provide four models:
         - small (300M), text to music, # see: https://huggingface.co/facebook/musicgen-small
         - medium (1.5B), text to music, # see: https://huggingface.co/facebook/musicgen-medium


### PR DESCRIPTION
Single line change to use CPU as device if CUDA is not available to Torch will allow users without nVidia GPUs to run without extra arguments.  Default is to still use CUDA if available