### PR TITLE
pass torch.generator() as argument for deterministic generation

### DIFF
--- a/audiocraft/utils/utils.py
+++ b/audiocraft/utils/utils.py
@@ -9,6 +9,7 @@ from functools import wraps
 import hashlib
 import logging
 import typing as tp
+import random
 
 import flashy
 import flashy.distrib
@@ -72,7 +73,6 @@ def get_dataset_from_loader(dataloader):
     else:
         return dataset
 
-
 def multinomial(input: torch.Tensor, num_samples: int, replacement=False, *, generator=None):
     """torch.multinomial with arbitrary number of dimensions, and number of candidates on the last dimension.
 
@@ -87,13 +87,15 @@ def multinomial(input: torch.Tensor, num_samples: int, replacement=False, *, gen
             sampled from the multinomial probability distribution
             located in the last dimension of tensor input.
     """
+
+    
     input_ = input.reshape(-1, input.shape[-1])
     output_ = torch.multinomial(input_, num_samples=num_samples, replacement=replacement, generator=generator)
     output = output_.reshape(*list(input.shape[:-1]), -1)
     return output
 
 
-def sample_top_k(probs: torch.Tensor, k: int) -> torch.Tensor:
+def sample_top_k(probs: torch.Tensor, k: int, generator=None) -> torch.Tensor:
     """Sample next token from top K values along the last dimension of the input probs tensor.
 
     Args:
@@ -106,11 +108,11 @@ def sample_top_k(probs: torch.Tensor, k: int) -> torch.Tensor:
     min_value_top_k = top_k_value[..., [-1]]
     probs *= (probs >= min_value_top_k).float()
     probs.div_(probs.sum(dim=-1, keepdim=True))
-    next_token = multinomial(probs, num_samples=1)
+    next_token = multinomial(probs, num_samples=1, generator=generator)
     return next_token
 
 
-def sample_top_p(probs: torch.Tensor, p: float) -> torch.Tensor:
+def sample_top_p(probs: torch.Tensor, p: float, generator=None) -> torch.Tensor:
     """Sample next token from top P probabilities along the last dimension of the input probs tensor.
 
     Args:
@@ -124,7 +126,7 @@ def sample_top_p(probs: torch.Tensor, p: float) -> torch.Tensor:
     mask = probs_sum - probs_sort > p
     probs_sort *= (~mask).float()
     probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
-    next_token = multinomial(probs_sort, num_samples=1)
+    next_token = multinomial(probs_sort, num_samples=1, generator=generator)
     next_token = torch.gather(probs_idx, -1, next_token)
     return next_token
 


### PR DESCRIPTION
not sure if there is a more proper way but found that by adding to generate(), lm() and utils functions the possibility to pass a torch.generator() as argument lets me get deterministic results.