### PR TITLE
Update Readme: Add links to Replicate deployment of MusicGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Check out our [sample page][musicgen_samples] or test the available demo!
 <a target="_blank" href="https://huggingface.co/spaces/facebook/MusicGen">
   <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/open-in-hf-spaces-sm.svg" alt="Open in HugginFace"/>
 </a>
-<a target="_blank" href="https://replicate.com/joehoover/musicgen">
-  <img src="https://replicate.com/joehoover/musicgen/badge" alt="Run on Replicate"/>
+<a target="_blank" href="https://replicate.com/facebookresearch/musicgen">
+  <img src="https://replicate.com/facebookresearch/musicgen/badge" alt="Run on Replicate"/>
 </a>
 <br>
 
@@ -48,7 +48,7 @@ We offer a number of way to interact with MusicGen:
 5. Checkout [@camenduru Colab page](https://github.com/camenduru/MusicGen-colab) which is regularly
   updated with contributions from @camenduru and the community.
 6. MusicGen is available in 🤗 Transformers from v4.31.0 onwards, see section [🤗 Transformers Usage](#-transformers-usage) below.
-7. Finally, MusicGen is also [hosted](https://replicate.com/joehoover/musicgen) on Replicate, where you can interact with the model via web UI or API.
+7. Finally, MusicGen is also [hosted](https://replicate.com/facebookresearch/musicgen) on Replicate, where you can interact with the model via web UI or API.
 
 
 ## API

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Audiocraft provides the code and models for MusicGen, [a simple and controllable
 Transformer model trained over a 32kHz <a href="https://github.com/facebookresearch/encodec">EnCodec tokenizer</a> with 4 codebooks sampled at 50 Hz. Unlike existing methods like [MusicLM](https://arxiv.org/abs/2301.11325), MusicGen doesn't require a self-supervised semantic representation, and it generates
 all 4 codebooks in one pass. By introducing a small delay between the codebooks, we show we can predict
 them in parallel, thus having only 50 auto-regressive steps per second of audio.
-Check out our [sample page][musicgen_samples], test our Hugging Face Spaces demo, or run MusicGen with Replicate's web UI or API.
+Check out our [sample page][musicgen_samples] or test the available demo!
 
 <a target="_blank" href="https://colab.research.google.com/drive/1-Xe9NCdIs2sCUbiSmwHXozK6AAhMm7_i?usp=sharing">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
@@ -23,7 +23,6 @@ Check out our [sample page][musicgen_samples], test our Hugging Face Spaces demo
   <img src="https://replicate.com/joehoover/musicgen/badge" alt="Run on Replicate"/>
 </a>
 <br>
-
 
 We use 20K hours of licensed music to train MusicGen. Specifically, we rely on an internal dataset of 10K high-quality music tracks, and on the ShutterStock and Pond5 music data.
 
@@ -48,8 +47,10 @@ We offer a number of way to interact with MusicGen:
 4. You can play with MusicGen by running the jupyter notebook at [`demo.ipynb`](./demo.ipynb) locally (if you have a GPU).
 5. Checkout [@camenduru Colab page](https://github.com/camenduru/MusicGen-colab) which is regularly
   updated with contributions from @camenduru and the community.
-6. MusicGen is also [hosted](https://replicate.com/joehoover/musicgen) on Replicate, where you can interact with the model via web UI or API.
-   
+6. MusicGen is available in 🤗 Transformers from v4.31.0 onwards, see section [🤗 Transformers Usage](#-transformers-usage) below.
+7. Finally, MusicGen is also [hosted](https://replicate.com/joehoover/musicgen) on Replicate, where you can interact with the model via web UI or API.
+
+
 ## API
 
 We provide a simple API and 4 pre-trained models. The pre trained models are:
@@ -90,6 +91,56 @@ for idx, one_wav in enumerate(wav):
     audio_write(f'{idx}', one_wav.cpu(), model.sample_rate, strategy="loudness", loudness_compressor=True)
 ```
 
+## 🤗 Transformers Usage
+
+MusicGen is available in the 🤗 Transformers library from version 4.31.0 onwards, requiring minimal dependencies 
+and additional packages. Steps to get started:
+
+1. First install the 🤗 [Transformers library](https://github.com/huggingface/transformers) from main:
+
+```
+pip install git+https://github.com/huggingface/transformers.git
+```
+
+2. Run the following Python code to generate text-conditional audio samples:
+
+```py
+from transformers import AutoProcessor, MusicgenForConditionalGeneration
+
+
+processor = AutoProcessor.from_pretrained("facebook/musicgen-small")
+model = MusicgenForConditionalGeneration.from_pretrained("facebook/musicgen-small")
+
+inputs = processor(
+    text=["80s pop track with bassy drums and synth", "90s rock song with loud guitars and heavy drums"],
+    padding=True,
+    return_tensors="pt",
+)
+
+audio_values = model.generate(**inputs, max_new_tokens=256)
+```
+
+3. Listen to the audio samples either in an ipynb notebook:
+
+```py
+from IPython.display import Audio
+
+sampling_rate = model.config.audio_encoder.sampling_rate
+Audio(audio_values[0].numpy(), rate=sampling_rate)
+```
+
+Or save them as a `.wav` file using a third-party library, e.g. `scipy`:
+
+```py
+import scipy
+
+sampling_rate = model.config.audio_encoder.sampling_rate
+scipy.io.wavfile.write("musicgen_out.wav", rate=sampling_rate, data=audio_values[0, 0].numpy())
+```
+
+For more details on using the MusicGen model for inference using the 🤗 Transformers library, refer to the 
+[MusicGen docs](https://huggingface.co/docs/transformers/main/en/model_doc/musicgen) or the hands-on 
+[Google Colab](https://colab.research.google.com/github/sanchit-gandhi/notebooks/blob/main/MusicGen.ipynb).
 
 ## Model Card
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Audiocraft provides the code and models for MusicGen, [a simple and controllable
 Transformer model trained over a 32kHz <a href="https://github.com/facebookresearch/encodec">EnCodec tokenizer</a> with 4 codebooks sampled at 50 Hz. Unlike existing methods like [MusicLM](https://arxiv.org/abs/2301.11325), MusicGen doesn't require a self-supervised semantic representation, and it generates
 all 4 codebooks in one pass. By introducing a small delay between the codebooks, we show we can predict
 them in parallel, thus having only 50 auto-regressive steps per second of audio.
-Check out our [sample page][musicgen_samples] or test the available demo!
+Check out our [sample page][musicgen_samples], test our Hugging Face Spaces demo, or run MusicGen with Replicate's web UI or API.
 
 <a target="_blank" href="https://colab.research.google.com/drive/1-Xe9NCdIs2sCUbiSmwHXozK6AAhMm7_i?usp=sharing">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
@@ -19,7 +19,11 @@ Check out our [sample page][musicgen_samples] or test the available demo!
 <a target="_blank" href="https://huggingface.co/spaces/facebook/MusicGen">
   <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/open-in-hf-spaces-sm.svg" alt="Open in HugginFace"/>
 </a>
+<a target="_blank" href="https://replicate.com/joehoover/musicgen">
+  <img src="https://replicate.com/joehoover/musicgen/badge" alt="Run on Replicate"/>
+</a>
 <br>
+
 
 We use 20K hours of licensed music to train MusicGen. Specifically, we rely on an internal dataset of 10K high-quality music tracks, and on the ShutterStock and Pond5 music data.
 
@@ -42,9 +46,10 @@ We offer a number of way to interact with MusicGen:
 2. You can run the Gradio demo in Colab: [colab notebook](https://colab.research.google.com/drive/1fxGqfg96RBUvGxZ1XXN07s3DthrKUl4-?usp=sharing).
 3. You can use the gradio demo locally by running `python app.py`.
 4. You can play with MusicGen by running the jupyter notebook at [`demo.ipynb`](./demo.ipynb) locally (if you have a GPU).
-5. Finally, checkout [@camenduru Colab page](https://github.com/camenduru/MusicGen-colab) which is regularly
+5. Checkout [@camenduru Colab page](https://github.com/camenduru/MusicGen-colab) which is regularly
   updated with contributions from @camenduru and the community.
-
+6. MusicGen is also [hosted](https://replicate.com/joehoover/musicgen) on Replicate, where you can interact with the model via web UI or API.
+   
 ## API
 
 We provide a simple API and 4 pre-trained models. The pre trained models are:


### PR DESCRIPTION
I've deployed a public instance of MusicGen on Replicate [here](https://replicate.com/facebookresearch/musicgen). This pull request adds a run-on-replicate badge and a note about the deployment to the Readme.

Let me know if you'd like to see any changes!