### PR TITLE
Fix: Use facebook/musicgen-small instead of facebook/musicgen-large

### DIFF
--- a/demos/musicgen_demo.ipynb
+++ b/demos/musicgen_demo.ipynb
@@ -27,7 +27,7 @@
     "import torch\n",
     "USE_DIFFUSION_DECODER = False\n",
     "# Using small model, better results would be obtained with `medium` or `large`.\n",
-    "model = MusicGen.get_pretrained('facebook/musicgen-large')\n",
+    "model = MusicGen.get_pretrained('facebook/musicgen-small')\n",
     "if USE_DIFFUSION_DECODER:\n",
     "    mbd = MultiBandDiffusion.get_mbd_musicgen()"
    ]


### PR DESCRIPTION
This pull request fixes the mistake in the code where `facebook/musicgen-large` was being used instead of `facebook/musicgen-small`, which is the model that was intended to be used for quicker results.