### PR TITLE
Right call for Encodec Model

### DIFF
--- a/docs/MBD.md
+++ b/docs/MBD.md
@@ -61,7 +61,7 @@ from audiocraft.data.audio import audio_read, audio_write
 
 bandwidth = 3.0  # 1.5, 3.0, 6.0
 mbd = MultiBandDiffusion.get_mbd_24khz(bw=bandwidth)
-encodec = EncodecModel.get_encodec_24khz()
+encodec = EncodecModel.encodec_model_24khz()
 
 somepath = ''
 wav, sr = audio_read(somepath)


### PR DESCRIPTION
Using the Encodec model requires a different function call. Made the change in the ReadMe for users to better utilize the comparison.