### PR TITLE
Add transformers hub usage mbd

### DIFF
--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -119,8 +119,8 @@ def load_mbd_ckpt(file_or_url_or_id: tp.Union[Path, str], cache_dir: tp.Optional
     return _get_state_dict(file_or_url_or_id, filename="all_in_one.pt", cache_dir=cache_dir)
 
 
-def load_diffusion_models(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_dir: tp.Optional[str] = None):
-    pkg = load_mbd_ckpt(file_or_url_or_id, cache_dir=cache_dir)
+def load_diffusion_models(file_or_url_or_id: tp.Union[Path, str], device='cpu', filename: tp.Optional[str] = None, cache_dir: tp.Optional[str] = None):
+    pkg = load_mbd_ckpt(file_or_url_or_id, filename=filename, cache_dir=cache_dir)
     models = []
     processors = []
     cfgs = []

--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -115,8 +115,8 @@ def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_di
     return model
 
 
-def load_mbd_ckpt(file_or_url_or_id: tp.Union[Path, str], cache_dir: tp.Optional[str] = None):
-    return _get_state_dict(file_or_url_or_id, filename="all_in_one.pt", cache_dir=cache_dir)
+def load_mbd_ckpt(file_or_url_or_id: tp.Union[Path, str], filename: tp.Optional[str] = None, cache_dir: tp.Optional[str] = None):
+    return _get_state_dict(file_or_url_or_id, filename=filename, cache_dir=cache_dir)
 
 
 def load_diffusion_models(file_or_url_or_id: tp.Union[Path, str], device='cpu', filename: tp.Optional[str] = None, cache_dir: tp.Optional[str] = None):

--- a/audiocraft/models/multibanddiffusion.py
+++ b/audiocraft/models/multibanddiffusion.py
@@ -104,7 +104,7 @@ class MultiBandDiffusion:
         codec_model.set_num_codebooks(n_q)
         codec_model = codec_model.to(device)
         path = 'facebook/multiband-diffusion'
-        filename = 'mbd_comp_{n_q}.pt'
+        filename = f'mbd_comp_{n_q}.pt'
         models, processors, cfgs = load_diffusion_models(path, filename=filename, device=device)
         DPs = []
         for i in range(len(models)):

--- a/audiocraft/models/multibanddiffusion.py
+++ b/audiocraft/models/multibanddiffusion.py
@@ -68,10 +68,11 @@ class MultiBandDiffusion:
         """Load our diffusion models trained for MusicGen."""
         if device is None:
             device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        path = 'https://dl.fbaipublicfiles.com/encodec/Diffusion/mbd_musicgen_32khz.th'
+        path = 'facebook/multiband-diffusion'
+        filename = 'mbd_musicgen_32khz.th'
         name = 'facebook/musicgen-small'
         codec_model = load_compression_model(name, device=device)
-        models, processors, cfgs = load_diffusion_models(path, device=device)
+        models, processors, cfgs = load_diffusion_models(path, filename=filename, device=device)
         DPs = []
         for i in range(len(models)):
             schedule = NoiseSchedule(**cfgs[i].schedule, sample_processor=processors[i])
@@ -102,8 +103,9 @@ class MultiBandDiffusion:
             '//pretrained/facebook/encodec_24khz', device=device)
         codec_model.set_num_codebooks(n_q)
         codec_model = codec_model.to(device)
-        path = f'https://dl.fbaipublicfiles.com/encodec/Diffusion/mbd_comp_{n_q}.pt'
-        models, processors, cfgs = load_diffusion_models(path, device=device)
+        path = 'facebook/multiband-diffusion'
+        filename = 'mbd_comp_{n_q}.pt'
+        models, processors, cfgs = load_diffusion_models(path, filename=filename, device=device)
         DPs = []
         for i in range(len(models)):
             schedule = NoiseSchedule(**cfgs[i].schedule, sample_processor=processors[i])


### PR DESCRIPTION
In order to democratize usage and facilitate access to MBD models, I've added the MultiBand Diffusion weights to an HF hub repo here: [facebook/multiband-diffusion](https://huggingface.co/facebook/multiband-diffusion).

This PR thus aims to facilitate access to these weights by slightly changing the loading mechanism of these MBD diffusion weights, similarly to what has been done for Encodec.

Many thanks for the great work behind audiocraft! I would be happy to get feedback on this PR! 