### PR TITLE
fix: update cache parameters to enable local model storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ dataset/*
 /notebooks
 /local_scripts
 /notes
+/models/

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -141,6 +141,7 @@ def get_conditioner_provider(output_dim: int, cfg: omegaconf.DictConfig, cache_d
                 output_dim=output_dim,
                 duration=duration,
                 device=device,
+                cache_dir=cache_dir,
                 **model_args
             )
         elif model_type == 'clap':

--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -55,7 +55,7 @@ def _get_state_dict(
         return torch.load(file, map_location=device)
 
     elif file_or_url_or_id.startswith('https://'):
-        return torch.hub.load_state_dict_from_url(file_or_url_or_id, map_location=device, check_hash=True)
+        return torch.hub.load_state_dict_from_url(file_or_url_or_id, map_location=device, check_hash=True, model_dir=cache_dir)
 
     else:
         assert filename is not None, "filename needs to be defined if using HF checkpoints"
@@ -108,7 +108,7 @@ def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_di
     _delete_param(cfg, 'conditioners.self_wav.chroma_stem.cache_path')
     _delete_param(cfg, 'conditioners.args.merge_text_conditions_p')
     _delete_param(cfg, 'conditioners.args.drop_desc_p')
-    model = builders.get_lm_model(cfg)
+    model = builders.get_lm_model(cfg, cache_dir=cache_dir)
     model.load_state_dict(pkg['best_state'])
     model.eval()
     model.cfg = cfg

--- a/audiocraft/models/multibanddiffusion.py
+++ b/audiocraft/models/multibanddiffusion.py
@@ -64,14 +64,14 @@ class MultiBandDiffusion:
         return self.codec_model.sample_rate
 
     @staticmethod
-    def get_mbd_musicgen(device=None):
+    def get_mbd_musicgen(device=None, cache_dir:str = None):
         """Load our diffusion models trained for MusicGen."""
         if device is None:
             device = 'cuda' if torch.cuda.is_available() else 'cpu'
         path = 'https://dl.fbaipublicfiles.com/encodec/Diffusion/mbd_musicgen_32khz.th'
         name = 'facebook/musicgen-small'
-        codec_model = load_compression_model(name, device=device)
-        models, processors, cfgs = load_diffusion_models(path, device=device)
+        codec_model = load_compression_model(name, device=device, cache_dir=cache_dir)
+        models, processors, cfgs = load_diffusion_models(path, device=device, cache_dir=cache_dir)
         DPs = []
         for i in range(len(models)):
             schedule = NoiseSchedule(**cfgs[i].schedule, sample_processor=processors[i], device=device)

--- a/audiocraft/models/musicgen.py
+++ b/audiocraft/models/musicgen.py
@@ -85,7 +85,7 @@ class MusicGen:
         return self.compression_model.channels
 
     @staticmethod
-    def get_pretrained(name: str = 'facebook/musicgen-melody', device=None):
+    def get_pretrained(name: str = 'facebook/musicgen-melody', device=None, cache_dir=None):
         """Return pretrained model, we provide four models:
         - facebook/musicgen-small (300M), text to music,
           # see: https://huggingface.co/facebook/musicgen-small
@@ -113,9 +113,8 @@ class MusicGen:
                 "MusicGen pretrained model relying on deprecated checkpoint mapping. " +
                 f"Please use full pre-trained id instead: facebook/musicgen-{name}")
             name = _HF_MODEL_CHECKPOINTS_MAP[name]
-
-        lm = load_lm_model(name, device=device)
-        compression_model = load_compression_model(name, device=device)
+        lm = load_lm_model(name, device=device, cache_dir=cache_dir)
+        compression_model = load_compression_model(name, device=device, cache_dir=cache_dir)
         if 'self_wav' in lm.condition_provider.conditioners:
             lm.condition_provider.conditioners['self_wav'].match_len_on_eval = True
 

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -389,7 +389,7 @@ class T5Conditioner(TextConditioner):
 
     def __init__(self, name: str, output_dim: int, finetune: bool, device: str,
                  autocast_dtype: tp.Optional[str] = 'float32', word_dropout: float = 0.,
-                 normalize_text: bool = False):
+                 normalize_text: bool = False, cache_dir: str = None):
         assert name in self.MODELS, f"Unrecognized t5 model name (should in {self.MODELS})"
         super().__init__(self.MODELS_DIMS[name], output_dim)
         self.device = device
@@ -412,8 +412,8 @@ class T5Conditioner(TextConditioner):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             try:
-                self.t5_tokenizer = T5Tokenizer.from_pretrained(name)
-                t5 = T5EncoderModel.from_pretrained(name).train(mode=finetune)
+                self.t5_tokenizer = T5Tokenizer.from_pretrained(name, cache_dir=cache_dir)
+                t5 = T5EncoderModel.from_pretrained(name, cache_dir=cache_dir).train(mode=finetune)
             finally:
                 logging.disable(previous_level)
         if finetune:

--- a/audiocraft/modules/demucs_custom.py
+++ b/audiocraft/modules/demucs_custom.py
@@ -1,0 +1,49 @@
+import torch
+
+from demucs.pretrained import *
+from demucs.pretrained import _parse_remote_files
+from demucs.apply import Model
+from demucs.states import load_model
+
+
+class CustomRemoteRepo(RemoteRepo):
+    def __init__(self, models: tp.Dict[str, str], cache_dir: str = None):
+        super().__init__(models)
+
+        self.cache_dir = cache_dir
+
+    def get_model(self, sig: str) -> Model:
+        try:
+            url = self._models[sig]
+        except KeyError:
+            raise ModelLoadingError(
+                f"Could not find a pre-trained model with signature {sig}."
+            )
+        pkg = torch.hub.load_state_dict_from_url(
+            url, map_location="cpu", check_hash=True, model_dir=self.cache_dir
+        )  # type: ignore
+        return load_model(pkg)
+
+
+# modified: from demucs import pretrained
+# self.__dict__['demucs'] = pretrained.get_model('htdemucs').to(device)
+def get_demucs_model(name: str, repo: tp.Optional[Path] = None, cache_dir: str = None):
+    """`name` must be a bag of models name or a pretrained signature
+    from the remote AWS model repo or the specified local repo if `repo` is not None.
+    """
+    if name == "demucs_unittest":
+        return demucs_unittest()
+    model_repo: ModelOnlyRepo
+    if repo is None:
+        models = _parse_remote_files(REMOTE_ROOT / "files.txt")
+        model_repo = CustomRemoteRepo(models, cache_dir)
+        bag_repo = BagOnlyRepo(REMOTE_ROOT, model_repo)
+    else:
+        if not repo.is_dir():
+            fatal(f"{repo} must exist and be a directory.")
+        model_repo = LocalRepo(repo)
+        bag_repo = BagOnlyRepo(repo, model_repo)
+    any_repo = AnyModelRepo(model_repo, bag_repo)
+    model = any_repo.get_model(name)
+    model.eval()
+    return model

--- a/demos/musicgen_app.py
+++ b/demos/musicgen_app.py
@@ -24,6 +24,21 @@ from audiocraft.data.audio_utils import convert_audio
 from audiocraft.data.audio import audio_write
 from audiocraft.models import MusicGen, MultiBandDiffusion
 
+from pathlib import Path
+import os
+
+
+ROOT = Path(__file__).parent.parent
+
+print("Root path: ", ROOT)
+
+OUTPUTS_PATH = ROOT / "outputs"
+MODELS_PATH = ROOT / "models"
+
+# make sure they exist
+os.makedirs(OUTPUTS_PATH, exist_ok=True)
+os.makedirs(MODELS_PATH, exist_ok=True)
+
 
 MODEL = None  # Last used model
 IS_BATCHED = "facebook/MusicGen" in os.environ.get('SPACE_ID', '')
@@ -87,11 +102,11 @@ def make_waveform(*args, **kwargs):
         return out
 
 
-def load_model(version='facebook/musicgen-melody'):
+def load_model(version='facebook/musicgen-melody', cache_dir=MODELS_PATH):
     global MODEL
     print("Loading model", version)
     if MODEL is None or MODEL.name != version:
-        MODEL = MusicGen.get_pretrained(version)
+        MODEL = MusicGen.get_pretrained(version, cache_dir=cache_dir)
 
 
 def load_diffusion():

--- a/demos/musicgen_app.py
+++ b/demos/musicgen_app.py
@@ -32,11 +32,7 @@ ROOT = Path(__file__).parent.parent
 
 print("Root path: ", ROOT)
 
-OUTPUTS_PATH = ROOT / "outputs"
 MODELS_PATH = ROOT / "models"
-
-# make sure they exist
-os.makedirs(OUTPUTS_PATH, exist_ok=True)
 os.makedirs(MODELS_PATH, exist_ok=True)
 
 

--- a/demos/musicgen_demo.ipynb
+++ b/demos/musicgen_demo.ipynb
@@ -26,7 +26,7 @@
     "from audiocraft.models import MultiBandDiffusion\n",
     "import torch\n",
     "USE_DIFFUSION_DECODER = False\n",
-    "CACHE_DIR = 'local_models' # \n",
+    "CACHE_DIR = 'models'\n",
     "\n",
     "# Using small model, better results would be obtained with `medium` or `large`.\n",
     "model = MusicGen.get_pretrained('facebook/musicgen-small', cache_dir=CACHE_DIR)\n",

--- a/demos/musicgen_demo.ipynb
+++ b/demos/musicgen_demo.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "from audiocraft.models import MusicGen\n",
     "from audiocraft.models import MultiBandDiffusion\n",
-    "import torch\n",
+    "\n",
     "USE_DIFFUSION_DECODER = False\n",
     "CACHE_DIR = 'models'\n",
     "\n",

--- a/demos/musicgen_demo.ipynb
+++ b/demos/musicgen_demo.ipynb
@@ -26,10 +26,12 @@
     "from audiocraft.models import MultiBandDiffusion\n",
     "import torch\n",
     "USE_DIFFUSION_DECODER = False\n",
+    "CACHE_DIR = 'local_models' # \n",
+    "\n",
     "# Using small model, better results would be obtained with `medium` or `large`.\n",
-    "model = MusicGen.get_pretrained('facebook/musicgen-small')\n",
+    "model = MusicGen.get_pretrained('facebook/musicgen-small', cache_dir=CACHE_DIR)\n",
     "if USE_DIFFUSION_DECODER:\n",
-    "    mbd = MultiBandDiffusion.get_mbd_musicgen()"
+    "    mbd = MultiBandDiffusion.get_mbd_musicgen(cache_dir=CACHE_DIR)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ librosa
 gradio
 torchmetrics
 encodec
+protobuf


### PR DESCRIPTION
- updated cache parameters in loaders to reach model downloader
- added custom demucs script to allow configuring cache dir
- added /models/ to .gitignore to ignore downloaded models
fixes: #234, #218, #100 

usage:

```python
from audiocraft.models import MusicGen
from audiocraft.models import MultiBandDiffusion
import torch
USE_DIFFUSION_DECODER = False
CACHE_DIR = 'models'

# Using small model, better results would be obtained with `medium` or `large`.
model = MusicGen.get_pretrained('facebook/musicgen-small', cache_dir=CACHE_DIR)
if USE_DIFFUSION_DECODER:
    mbd = MultiBandDiffusion.get_mbd_musicgen(cache_dir=CACHE_DIR)
```