### PR TITLE
Use double quotes for better compatibility (REAMDE / ffmpeg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We also recommend having `ffmpeg` installed, either through your system or Anaco
 ```bash
 sudo apt-get install ffmpeg
 # Or if you are using Anaconda or Miniconda
-conda install 'ffmpeg<5' -c  conda-forge
+conda install "ffmpeg<5" -c conda-forge
 ```
 
 ## Models


### PR DESCRIPTION
`conda install 'ffmpeg<5' -c conda-forge` will results with "The system cannot find the file specified." on Windows.

Using `"` (double quotes) provide better compatibility and results in the correct behavior on Windows.