### PR TITLE
Fix `get_bip_bip` function not using frequency param

### DIFF
--- a/demos/audiogen_demo.ipynb
+++ b/demos/audiogen_demo.ipynb
@@ -83,7 +83,7 @@
     "    \"\"\"Generates a series of bip bip at the given frequency.\"\"\"\n",
     "    t = torch.arange(\n",
     "        int(duration * sample_rate), device=\"cuda\", dtype=torch.float) / sample_rate\n",
-    "    wav = torch.cos(2 * math.pi * 440 * t)[None]\n",
+    "    wav = torch.cos(2 * math.pi * frequency * t)[None]\n",
     "    tp = (t % (2 * bip_duration)) / (2 * bip_duration)\n",
     "    envelope = (tp >= 0.5).float()\n",
     "    return wav * envelope"


### PR DESCRIPTION
On Audiogen's demo notebook, a `get_bip_bip` function is defined to generate beep sounds at a given frequency, taking said frequency in Hz as a param.

However, the body of the function was not taking that frequency param into account and had a hardcoded `440`Hz value.