### PR TITLE
Replace flake8 with Ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ install:
 	pip install -U -e '.[dev]'
 
 linter:
-	flake8 audiocraft && mypy audiocraft
-	flake8 tests && mypy tests
+	ruff audiocraft && mypy audiocraft
+	ruff tests && mypy tests
 
 tests:
 	coverage run -m pytest tests

--- a/audiocraft/__init__.py
+++ b/audiocraft/__init__.py
@@ -20,7 +20,13 @@ At the moment we provide the training code for:
     improves the perceived quality and reduces the artifacts coming from adversarial decoders.
 """
 
-# flake8: noqa
+
 from . import data, modules, models
 
 __version__ = '1.0.0'
+
+__all__ = [
+    'data',
+    'models',
+    'modules',
+]

--- a/audiocraft/adversarial/__init__.py
+++ b/audiocraft/adversarial/__init__.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 """Adversarial losses and discriminator architectures."""
 
-# flake8: noqa
 from .discriminators import (
     MultiPeriodDiscriminator,
     MultiScaleDiscriminator,
@@ -20,3 +19,16 @@ from .losses import (
     FeatLossType,
     FeatureMatchingLoss
 )
+
+__all__ = [
+    'AdvLossType',
+    'AdversarialLoss',
+    'FeatLossType',
+    'FeatureMatchingLoss',
+    'MultiPeriodDiscriminator',
+    'MultiScaleDiscriminator',
+    'MultiScaleSTFTDiscriminator',
+    'get_adv_criterion',
+    'get_fake_criterion',
+    'get_real_criterion',
+]

--- a/audiocraft/adversarial/discriminators/__init__.py
+++ b/audiocraft/adversarial/discriminators/__init__.py
@@ -4,7 +4,13 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-# flake8: noqa
+
 from .mpd import MultiPeriodDiscriminator
 from .msd import MultiScaleDiscriminator
 from .msstftd import MultiScaleSTFTDiscriminator
+
+__all__ = [
+    'MultiPeriodDiscriminator',
+    'MultiScaleDiscriminator',
+    'MultiScaleSTFTDiscriminator',
+]

--- a/audiocraft/data/__init__.py
+++ b/audiocraft/data/__init__.py
@@ -6,5 +6,12 @@
 """Audio loading and writing support. Datasets for raw audio
 or also including some metadata."""
 
-# flake8: noqa
 from . import audio, audio_dataset, info_audio_dataset, music_dataset, sound_dataset
+
+__all__ = [
+    'audio',
+    'audio_dataset',
+    'info_audio_dataset',
+    'music_dataset',
+    'sound_dataset',
+]

--- a/audiocraft/losses/__init__.py
+++ b/audiocraft/losses/__init__.py
@@ -6,7 +6,6 @@
 """Loss related classes and functions. In particular the loss balancer from
 EnCodec, and the usual spectral losses."""
 
-# flake8: noqa
 from .balancer import Balancer
 from .sisnr import SISNR
 from .stftloss import (
@@ -19,3 +18,14 @@ from .specloss import (
     MelSpectrogramL1Loss,
     MultiScaleMelSpectrogramLoss,
 )
+
+__all__ = [
+    'Balancer',
+    'LogSTFTMagnitudeLoss',
+    'MRSTFTLoss',
+    'MelSpectrogramL1Loss',
+    'MultiScaleMelSpectrogramLoss',
+    'SISNR',
+    'STFTLoss',
+    'SpectralConvergenceLoss',
+]

--- a/audiocraft/metrics/__init__.py
+++ b/audiocraft/metrics/__init__.py
@@ -5,10 +5,21 @@
 # LICENSE file in the root directory of this source tree.
 """Metrics like CLAP score, FAD, KLD, Visqol, Chroma similarity, etc.
 """
-# flake8: noqa
+
 from .clap_consistency import CLAPTextConsistencyMetric, TextConsistencyMetric
 from .chroma_cosinesim import ChromaCosineSimilarityMetric
 from .fad import FrechetAudioDistanceMetric
 from .kld import KLDivergenceMetric, PasstKLDivergenceMetric
 from .rvm import RelativeVolumeMel
 from .visqol import ViSQOL
+
+__all__ = [
+    'CLAPTextConsistencyMetric',
+    'ChromaCosineSimilarityMetric',
+    'FrechetAudioDistanceMetric',
+    'KLDivergenceMetric',
+    'PasstKLDivergenceMetric',
+    'RelativeVolumeMel',
+    'TextConsistencyMetric',
+    'ViSQOL',
+]

--- a/audiocraft/models/__init__.py
+++ b/audiocraft/models/__init__.py
@@ -6,7 +6,7 @@
 """
 Models for EnCodec, AudioGen, MusicGen, as well as the generic LMModel.
 """
-# flake8: noqa
+
 from . import builders, loaders
 from .encodec import (
     CompressionModel, EncodecModel, DAC,
@@ -16,3 +16,18 @@ from .lm import LMModel
 from .multibanddiffusion import MultiBandDiffusion
 from .musicgen import MusicGen
 from .unet import DiffusionUnet
+
+__all__ = [
+    'AudioGen',
+    'CompressionModel',
+    'DAC',
+    'DiffusionUnet',
+    'EncodecModel',
+    'HFEncodecCompressionModel',
+    'HFEncodecModel',
+    'LMModel',
+    'MultiBandDiffusion',
+    'MusicGen',
+    'builders',
+    'loaders',
+]

--- a/audiocraft/modules/__init__.py
+++ b/audiocraft/modules/__init__.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 """Modules used for building the models."""
 
-# flake8: noqa
 from .conv import (
     NormConv1d,
     NormConv2d,
@@ -20,3 +19,19 @@ from .conv import (
 from .lstm import StreamableLSTM
 from .seanet import SEANetEncoder, SEANetDecoder
 from .transformer import StreamingTransformer
+
+__all__ = [
+    'NormConv1d',
+    'NormConv2d',
+    'NormConvTranspose1d',
+    'NormConvTranspose2d',
+    'SEANetDecoder',
+    'SEANetEncoder',
+    'StreamableConv1d',
+    'StreamableConvTranspose1d',
+    'StreamableLSTM',
+    'StreamingTransformer',
+    'pad1d',
+    'pad_for_conv1d',
+    'unpad1d',
+]

--- a/audiocraft/modules/diffusion_schedule.py
+++ b/audiocraft/modules/diffusion_schedule.py
@@ -161,7 +161,7 @@ class NoiseSchedule:
         """Return 'alpha_bar', either for a given step, or as a tensor with its value for each step."""
         if step is None:
             return (1 - self.betas).cumprod(dim=-1)  # works for simgle and multi bands
-        if type(step) is int:
+        if isinstance(step, int):
             return (1 - self.betas[:step + 1]).prod()
         else:
             return (1 - self.betas).cumprod(dim=0)[step].view(-1, 1, 1)

--- a/audiocraft/optim/__init__.py
+++ b/audiocraft/optim/__init__.py
@@ -7,10 +7,18 @@
 and Exponential Moving Average.
 """
 
-# flake8: noqa
 from .cosine_lr_scheduler import CosineLRScheduler
 from .dadam import DAdaptAdam
 from .inverse_sqrt_lr_scheduler import InverseSquareRootLRScheduler
 from .linear_warmup_lr_scheduler import LinearWarmupLRScheduler
 from .polynomial_decay_lr_scheduler import PolynomialDecayLRScheduler
 from .ema import ModuleDictEMA
+
+__all__ = [
+    'CosineLRScheduler',
+    'DAdaptAdam',
+    'InverseSquareRootLRScheduler',
+    'LinearWarmupLRScheduler',
+    'ModuleDictEMA',
+    'PolynomialDecayLRScheduler',
+]

--- a/audiocraft/quantization/__init__.py
+++ b/audiocraft/quantization/__init__.py
@@ -4,6 +4,13 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 """RVQ."""
-# flake8: noqa
+
 from .vq import ResidualVectorQuantizer
 from .base import BaseQuantizer, DummyQuantizer, QuantizedResult
+
+__all__ = [
+    'BaseQuantizer',
+    'DummyQuantizer',
+    'QuantizedResult',
+    'ResidualVectorQuantizer',
+]

--- a/audiocraft/solvers/__init__.py
+++ b/audiocraft/solvers/__init__.py
@@ -8,10 +8,18 @@ Solvers. A Solver is a training recipe, combining the dataloaders, models,
 optimizer, losses etc into a single convenient object.
 """
 
-# flake8: noqa
 from .audiogen import AudioGenSolver
 from .builders import get_solver
 from .base import StandardSolver
 from .compression import CompressionSolver
 from .musicgen import MusicGenSolver
 from .diffusion import DiffusionSolver
+
+__all__ = [
+    'AudioGenSolver',
+    'CompressionSolver',
+    'DiffusionSolver',
+    'MusicGenSolver',
+    'StandardSolver',
+    'get_solver',
+]

--- a/audiocraft/solvers/diffusion.py
+++ b/audiocraft/solvers/diffusion.py
@@ -32,7 +32,7 @@ class PerStageMetrics:
         self.num_stages = num_stages
 
     def __call__(self, losses: dict, step: tp.Union[int, torch.Tensor]):
-        if type(step) is int:
+        if isinstance(step, int):
             stage = int((step / self.num_steps) * self.num_stages)
             return {f"{name}_{stage}": loss for name, loss in losses.items()}
         elif type(step) is torch.Tensor:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[pep8]
-max-line-length = 120
-
-[flake8]
-max-line-length = 120
-
 [coverage:report]
 include = audiocraft/*
 omit =

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     python_requires=REQUIRES_PYTHON,
     install_requires=REQUIRED,
     extras_require={
-        'dev': ['coverage', 'flake8', 'mypy', 'pdoc3', 'pytest'],
+        'dev': ['coverage', 'ruff==0.0.291', 'mypy', 'pdoc3', 'pytest'],
     },
     packages=find_packages(),
     package_data={'audiocraft': ['py.typed']},

--- a/tests/common_utils/__init__.py
+++ b/tests/common_utils/__init__.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-# flake8: noqa
 from .temp_utils import TempDirMixin
 from .wav_utils import get_batch_white_noise, get_white_noise, save_wav
+
+__all__ = [
+    'TempDirMixin',
+    'get_batch_white_noise',
+    'get_white_noise',
+    'save_wav',
+]


### PR DESCRIPTION
This PR replaces `flake8` with [ruff](https://github.com/astral-sh/ruff).

It does not (yet!) enable any additional rules beyond those enabled by the default Ruff ruleset (but there's a whole bunch of potential bugs that could be uncovered with the `B` class of lints, etc.).