### PR TITLE
Fix musigen app memory issue

### DIFF
--- a/demos/musicgen_app.py
+++ b/demos/musicgen_app.py
@@ -73,14 +73,6 @@ class FileCleaner:
             else:
                 break
                 
-    def delete_all(self):
-        # delete regardless of file's life time
-        for _, path in list(self.files):
-            if path.exists():
-                path.unlink()
-        self.files = []
-
-
 file_cleaner = FileCleaner()
 
 
@@ -113,9 +105,7 @@ def load_diffusion():
 
 
 def _do_predictions(texts, melodies, duration, progress=False, **gen_kwargs):
-    # get rid of temp files
-    file_cleaner.delete_all()
-    
+   
     MODEL.set_generation_params(duration=duration, **gen_kwargs)
     print("new batch", len(texts), texts, [None if m is None else (m[0], m[1].shape) for m in melodies])
     be = time.time()


### PR DESCRIPTION
Fixes 2 issues:

- There was a memory issue where models stayed in memory when models were changed. To replicate the issue: when the model was changed  from melody to the medium model, the melody model would remain in memory whilst the medium model was also loaded into memory, consuming large amounts of RAM. 

-  Once someone clicked the submit button, the old temp files were not removed and stayed on disk (until lifetime was reached). Added another function in the filecleaner to remove these files since they cannot be accessed from the UI anyway once someone regenerates their samples.