### PR TITLE
add `library_name` parameter to `hf_hub_download` for better model tracking on the Hub.

### DIFF
--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -60,7 +60,7 @@ def _get_state_dict(
     else:
         assert filename is not None, "filename needs to be defined if using HF checkpoints"
 
-        file = hf_hub_download(repo_id=file_or_url_or_id, filename=filename, cache_dir=cache_dir)
+        file = hf_hub_download(repo_id=file_or_url_or_id, filename=filename, cache_dir=cache_dir, library_name="audiocraft")
         return torch.load(file, map_location=device)
 
 


### PR DESCRIPTION
Hi there,

hf_hub_download in the huggingface_hub package allows for better cache management and tracking for the model checkpoint usage.

I've only added the capability to track with the `library_name` for now, we can also add a `library_version` to allow for more fine-grained control over the model checkpoint cache.