### PR TITLE
fix: unprompted generation for musicgen

### DIFF
--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -410,7 +410,7 @@ class MusicGenSolver(base.StandardSolver):
         Args:
             batch (tuple[torch.Tensor, list[SegmentWithAttributes]]):
             gen_duration (float): Target audio duration for the generation.
-            prompt_duration (float, optional): Duration for the audio prompt to use for continuation. Set to None for unpromted generation.
+            prompt_duration (float, optional): Duration for the audio prompt to use for continuation. Set to None for unprompted generation.
             remove_prompt (bool, optional): Whether to remove the prompt from the generated audio.
             generation_params: Additional generation parameters.
         Returns:

--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -409,9 +409,8 @@ class MusicGenSolver(base.StandardSolver):
 
         Args:
             batch (tuple[torch.Tensor, list[SegmentWithAttributes]]):
-            use_prompt (bool): Whether to do audio continuation generation with prompt from audio batch.
             gen_duration (float): Target audio duration for the generation.
-            prompt_duration (float, optional): Duration for the audio prompt to use for continuation.
+            prompt_duration (float, optional): Duration for the audio prompt to use for continuation. Set to None for unpromted generation.
             remove_prompt (bool, optional): Whether to remove the prompt from the generated audio.
             generation_params: Additional generation parameters.
         Returns:
@@ -451,7 +450,8 @@ class MusicGenSolver(base.StandardSolver):
             total_gen_len = math.ceil(gen_duration * self.compression_model.frame_rate)
             gen_tokens = self.model.generate(
                 prompt_tokens, attributes, max_gen_len=total_gen_len,
-                num_samples=num_samples, **self.generation_params)
+                num_samples=num_samples, remove_prompts=remove_prompt,
+                **self.generation_params)
 
         # generate audio from tokens
         assert gen_tokens.dim() == 3

--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -533,9 +533,10 @@ class MusicGenSolver(base.StandardSolver):
                     rtf = 1.
                 else:
                     gen_unprompted_outputs = self.run_generate_step(
-                        batch, gen_duration=target_duration, prompt_duration=prompt_duration,
+                        batch, gen_duration=target_duration, prompt_duration=None,
                         **self.generation_params)
                     gen_unprompted_audio = gen_unprompted_outputs['gen_audio'].cpu()
+                    assert gen_outputs['prompt_audio'] is None
                     rtf = gen_unprompted_outputs['rtf']
                 sample_manager.add_samples(
                     gen_unprompted_audio, self.epoch, hydrated_conditions,


### PR DESCRIPTION
The unprompted examples created by `generate_audio` aren't unprompted. Since the call for prompted and unprompted is the same both will do audio continuation. By setting `prompted_duration = None` for the unprompted case we will not do audio continuations. I also added an assert on the output to make sure this would be caught in the future.  