### PR TITLE
Remove outdated assert for layer checkpointing.

### DIFF
--- a/audiocraft/modules/transformer.py
+++ b/audiocraft/modules/transformer.py
@@ -648,7 +648,6 @@ class StreamingTransformer(StreamingModule):
                 # see audiocraft/optim/fsdp.py, magic signal to indicate this requires fixing the
                 # backward hook inside of FSDP...
                 layer._magma_checkpointed = True  # type: ignore
-                assert layer.layer_drop == 0., "Need further checking"  # type: ignore
 
     def _apply_layer(self, layer, *args, **kwargs):
         method = self.checkpointing


### PR DESCRIPTION
Looks like this assert checks abandoned experimental `layer_drop` param, which not exists anymore.