### PR TITLE
Fix docstring and add condition_tensor attribute to lm.generate()

### DIFF
--- a/audiocraft/models/lm.py
+++ b/audiocraft/models/lm.py
@@ -395,11 +395,11 @@ class LMModel(StreamingModule):
                  check: bool = False,
                  callback: tp.Optional[tp.Callable[[int, int], None]] = None) -> torch.Tensor:
         """Generate tokens sampling from the model given a prompt or unconditionally. Generation can
-        be perform in a greedy fashion or using sampling with top K and top P strategies.
+        be performed in a greedy fashion or using sampling with top K and top P strategies.
 
         Args:
             prompt (torch.Tensor, optional): Prompt tokens of shape [B, K, T].
-            conditions_tensors (list of ConditioningAttributes, optional): List of conditions.
+            conditions (list of ConditioningAttributes, optional): List of conditions.
             num_samples (int, optional): Number of samples to generate when no prompt and no conditions are given.
             max_gen_len (int): Maximum generation length.
             use_sampling (bool): Whether to use a sampling strategy or not.

--- a/audiocraft/models/lm.py
+++ b/audiocraft/models/lm.py
@@ -383,6 +383,7 @@ class LMModel(StreamingModule):
     def generate(self,
                  prompt: tp.Optional[torch.Tensor] = None,
                  conditions: tp.List[ConditioningAttributes] = [],
+                 condition_tensors: tp.Optional[ConditionTensors] = None,
                  num_samples: tp.Optional[int] = None,
                  max_gen_len: int = 256,
                  use_sampling: bool = True,
@@ -400,6 +401,7 @@ class LMModel(StreamingModule):
         Args:
             prompt (torch.Tensor, optional): Prompt tokens of shape [B, K, T].
             conditions (list of ConditioningAttributes, optional): List of conditions.
+            condition_tensors (list of str, ConditionType, optional): List of pre-computed conditioning tensors
             num_samples (int, optional): Number of samples to generate when no prompt and no conditions are given.
             max_gen_len (int): Maximum generation length.
             use_sampling (bool): Whether to use a sampling strategy or not.
@@ -442,7 +444,9 @@ class LMModel(StreamingModule):
         # With a batch size of 1, this can be slower though.
         cfg_conditions: CFGConditions
         two_step_cfg = self.two_step_cfg if two_step_cfg is None else two_step_cfg
-        if conditions:
+        if condition_tensors:
+            cfg_conditions = condition_tensors
+        elif conditions:
             null_conditions = ClassifierFreeGuidanceDropout(p=1.0)(conditions)
             if two_step_cfg:
                 cfg_conditions = (


### PR DESCRIPTION
Hi,
first of all thank you for your amazing work here. I really enjoy working with MusicGen and the other tools of audiocraft!

I noticed an inconsistency between the docstring and the method signature of `lm.generate()`.  The `conditions` attribute wasn't mentioned in the docstring, but `condition_tensors` was.  As I would like to use the option to provide preprocessed `condition_tensors` to the generation method, I've added the attribute to the given method, similarly to `lm.forward()`. Therefore I'd like to ask wheater it is possible to include this method parameter into the method.

Kind Regards
Niklas