### PR TITLE
Update spaCy dependency so demo project can run

### DIFF
--- a/demos/musicgen_app.py
+++ b/demos/musicgen_app.py
@@ -256,7 +256,7 @@ def ui_full(launch_kwargs):
                     with gr.Column():
                         radio = gr.Radio(["file", "mic"], value="file",
                                          label="Condition on a melody (optional) File or Mic")
-                        melody = gr.Audio(source="upload", type="numpy", label="File",
+                        melody = gr.Audio(sources=["upload"], type="numpy", label="File",
                                           interactive=True, elem_id="melody-input")
                 with gr.Row():
                     submit = gr.Button("Submit")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ julius
 num2words
 numpy
 sentencepiece
-spacy==3.5.2
+spacy>=3.6.1
 torch==2.1.0
 torchaudio>=2.0.0
 huggingface_hub


### PR DESCRIPTION
Currently, the `musicgen_app.py` demo does not run; it fails with the following error:

> pydantic.errors.PydanticImportError: `pydantic:ConstrainedStr` has been removed in V2.

It is possible to resolve this error by upping the spaCy dependency, which is what's bringing in the old version of pydantic.

spaCy 3.6.1+ uses the new Pydantic version: https://github.com/explosion/spaCy/releases/tag/v3.6.1

Note: this PR is similar to https://github.com/facebookresearch/audiocraft/pull/278.