### PR TITLE
Magnet xformers 0.0.22 compatibility fix

### DIFF
--- a/audiocraft/grids/magnet/magnet_32khz.py
+++ b/audiocraft/grids/magnet/magnet_32khz.py
@@ -12,7 +12,7 @@ from ...environment import AudioCraftEnvironment
 def explorer(launcher):
     partitions = AudioCraftEnvironment.get_slurm_partitions(['team', 'global'])
     launcher.slurm_(gpus=32, partition=partitions)
-    launcher.bind_(solver='magnet/magnet_base_32khz')
+    launcher.bind_(solver='magnet/magnet_32khz')
     # replace this by the desired music dataset
     launcher.bind_(dset='internal/music_400k_32khz')
 

--- a/demos/magnet_demo.ipynb
+++ b/demos/magnet_demo.ipynb
@@ -60,7 +60,7 @@
     "    max_cfg_coef=10.0,\n",
     "    min_cfg_coef=1.0,\n",
     "    decoding_steps=[int(20 * model.lm.cfg.dataset.segment_duration // 10),  10, 10, 10],\n",
-    "    span_arrangement='nonoverlap'\n",
+    "    span_arrangement='stride1'\n",
     ")"
    ]
   },
@@ -153,7 +153,7 @@
     "    max_cfg_coef=20.0,\n",
     "    min_cfg_coef=1.0,\n",
     "    decoding_steps=[int(20 * model.lm.cfg.dataset.segment_duration // 10),  10, 10, 10],\n",
-    "    span_arrangement='nonoverlap'\n",
+    "    span_arrangement='stride1'\n",
     ")"
    ]
   },

--- a/docs/MAGNET.md
+++ b/docs/MAGNET.md
@@ -38,7 +38,7 @@ We provide a simple API and 6 pre-trained models. The pre trained models are:
 - `facebook/magnet-small-30secs`: 300M model, text to music, generates 30-second samples - [🤗 Hub](https://huggingface.co/facebook/magnet-small-30secs)
 - `facebook/magnet-medium-30secs`: 1.5B model, text to music, generates 30-second samples - [🤗 Hub](https://huggingface.co/facebook/magnet-medium-30secs)
 - `facebook/audio-magnet-small`: 300M model, text to sound-effect - [🤗 Hub](https://huggingface.co/facebook/audio-magnet-small)
-- `facebook/audio-magnet-small`: 300M model, text to sound-effect - [🤗 Hub](https://huggingface.co/facebook/audio-magnet-medium)
+- `facebook/audio-magnet-medium`: 1.5B model, text to sound-effect - [🤗 Hub](https://huggingface.co/facebook/audio-magnet-medium)
 
 In order to use MAGNeT locally **you must have a GPU**. We recommend 16GB of memory, especially for 
 the medium size models. 


### PR DESCRIPTION
MAGNeT - Fix for xformers 0.0.22 compatibility, thanks to @nateraw catch. 

* Inference was already tested
* Testing now training as well

In addition, the following smaller fixes are also contained in this PR:
* MAGNeT notebook - change to stride1 span arrangement by default which works better than the nonoverlap reported in the paper
* MAGNeT doc fix of a typo 
* MAGNeT music training grid typo fix 