### PR TITLE
fix typo in diffusion solver config

### DIFF
--- a/config/solver/diffusion/default.yaml
+++ b/config/solver/diffusion/default.yaml
@@ -29,8 +29,7 @@ dataset:
     batch_size: 32
     num_samples: 50
     segment_duration: 10
-    audio:
-      sample_rate: ${sample_rate}
+
 
 loss:
   kind: mse
@@ -50,7 +49,9 @@ evaluate:
 generate:
   every: 25
   num_workers: 5
-
+  audio:
+    sample_rate: ${sample_rate}
+    
 checkpoint:
   save_last: true
   save_every: 25


### PR DESCRIPTION
# What? 

This is probably an issue with the config file for the diffusion model. The generation sample rate should be added to the `generate` and not in `dataset.generate`

This `generate.audio` params are passed to `audio_write` functions save audio using ffmpeg in the following line 

https://github.com/facebookresearch/audiocraft/blob/69fea8b290ad1b4b40d28f92d1dfc0ab01dbab85/audiocraft/utils/samples/manager.py#L193


# Test 

```
python3 -m pdb -c c -m  dora run solver=diffusion/encodec_24khz execute_only=generate continue_from=/path_to_ckpt.th dset=audio/default

```