### PR TITLE
Fix FSDP support with pytorch 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Typo fixes.
 
 Fixing setup.py to install only audiocraft, not the unit tests and scripts.
 
+Fix FSDP support with PyTorch 2.1.0. 
+
 ## [1.2.0] - 2024-01-11
 
 Adding stereo models.

--- a/audiocraft/__init__.py
+++ b/audiocraft/__init__.py
@@ -23,4 +23,4 @@ At the moment we provide the training code for:
 # flake8: noqa
 from . import data, modules, models
 
-__version__ = '1.3.0a1'
+__version__ = '1.3.0a2'


### PR DESCRIPTION
Fix FSDP code wrote for torch 2.0 but breaking for 2.1.0 as raised by https://github.com/facebookresearch/audiocraft/issues/358 and https://github.com/facebookresearch/audiocraft/issues/450 .