### PR TITLE
Update dependencies to work with torch v2.2.x, 2.3.x etc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,19 +2,21 @@
 av==11.0.0
 einops
 flashy>=0.0.1
+huggingface_hub
 hydra-core>=1.1
 hydra_colorlog
 julius
 num2words
-numpy<2.0.0
+numpy>=1.26.4,<2.0.0
 sentencepiece
 spacy>=3.6.1
-torch==2.1.0
-torchaudio>=2.0.0,<2.1.2
-huggingface_hub
+torch>=2.1.0,<2.5.0
+torchaudio>=2.0.0,<2.5.0
+torchvision>=0.16.0,<0.20.0
+torchtext>=0.16.0,<0.20.0
 tqdm
 transformers>=4.31.0  # need Encodec there.
-xformers<0.0.23
+xformers>=0.0.22,<0.0.28
 demucs
 librosa
 soundfile
@@ -22,7 +24,5 @@ gradio
 torchmetrics
 encodec
 protobuf
-torchvision==0.16.0
-torchtext==0.16.0
 pesq
 pystoi


### PR DESCRIPTION
Audiocraft is cool but uses torch v2.1.0 as a dependency; installing it downgrades PyTorch in the whole environment, and when it's upgraded, `pip` issues a warning about mismatching versions.

Checked correct operations with v2.2.1, v2.3.0, v2.3.1 and v2.4.0.