### PR TITLE
Update AudioEffects with New Audio Attacks and Update Configuration

### DIFF
--- a/config/augmentations/default.yaml
+++ b/config/augmentations/default.yaml
@@ -41,6 +41,31 @@ audio_effects:
   encodec:
     ckpt: "//pretrained/facebook/encodec_24khz"
     n_qs: [4, 8, 16]
+  pitch_shift:
+    sample_rate: ${sample_rate}
+    n_steps: 2.0
+  clipping:
+    clip_value: 0.5
+  time_stretch:
+    sample_rate: ${sample_rate}
+    stretch_factor: 1.2
+  tremolo:
+    frequency: 5.0
+    depth: 0.5
+    sample_rate: ${sample_rate}
+  flanger:
+    delay: 0.002
+    depth: 0.002
+    rate: 0.25
+    sample_rate: ${sample_rate}
+  bit_crusher:
+    bit_depth: 8
+  ring_modulation:
+    modulation_frequency: 30.0
+    sample_rate: ${sample_rate}
+  granulate:
+    grain_size: 512
+    overlap: 0.5
 
 select_aug_mode:
   "use_eval" # other are 'all' and 'use_eval_acc', used to sample augmentations, `fixed` uses the prob from aug_weights, `all` uses all agmentations every step
@@ -61,5 +86,14 @@ aug_weights:
   aac_compression: 0.1 # eval only never use in training even if eval_acc low
   encodec: 0.1
   identity: 1 # no augmentation
+  pitch_shift: 0.1
+  reverse: 0.1
+  clipping: 0.1
+  time_stretch: 0.1
+  tremolo: 0.1
+  flanger: 0.1
+  bit_crusher: 0.1
+  ring_modulation: 0.1
+  granulate: 0.1
 
 n_max_aug: null


### PR DESCRIPTION
### Summary
Update new audio attacks to the `AudioEffects` class and update the configuration in `default.yaml` to reflect the newly added effects. 

### New Audio Effects Added:
1. **Pitch Shift**: Changes the pitch of the audio signal by a given number of steps without altering the duration.
2. **Reverse**: Reverses the entire audio signal, simulating a backward playback.
3. **Clipping**: Clips the audio signal to a specific threshold, introducing distortion.
4. **Time Stretch**: Changes the duration of the audio without modifying the pitch, useful for testing stretched audio scenarios.
5. **Tremolo**: Applies amplitude modulation to create a tremolo effect.
6. **Flanger**: Introduces a delayed version of the signal with periodic modulation, creating a swirling sound effect.
7. **Bit Crusher**: Reduces the bit depth of the audio signal, introducing digital distortion for lo-fi simulation.
8. **Ring Modulation**: Multiplies the audio signal with a sine wave, resulting in a metallic sound effect.
9. **Granulate**: Breaks the audio into overlapping grains, creating a stutter-like or granulated effect.

### Changes Made:
1. **AudioEffects Class**:
    - Add new methods for the above effects to expand the transformation possibilities.
    - Ensure all new methods return audio tensors consistent with the existing interface.

2. **default.yaml Configuration File**:
    - Add configurations for each of the newly added audio effects.
    - Included default parameters such as sample rates, modulation frequencies, bit depths, etc.
    - Updated `aug_weights` to include the new effects, with default weights for augmentation selection during evaluations.

Ref: https://github.com/facebookresearch/audioseal/pull/57
