### PR TITLE
bigfix, inference loading checkpoints use local path

### DIFF
--- a/.github/actions/audiocraft_build/action.yml
+++ b/.github/actions/audiocraft_build/action.yml
@@ -6,7 +6,7 @@ runs:
   - uses: actions/setup-python@v2
     with:
       python-version: 3.9
-  - uses: actions/cache@v2
+  - uses: actions/cache@v3
     id: cache
     with:
       path: env

--- a/audiocraft/modules/jasco_conditioners.py
+++ b/audiocraft/modules/jasco_conditioners.py
@@ -88,7 +88,7 @@ class DrumsConditioner(WaveformConditioner):
         self._use_masking = False
         self.blurring_factor = blurring_factor
         self.seq_len = int(segment_duration * compression_model_framerate)
-        self.cache = None # If you wish to train with EmbeddingCache, call self.create_embedding_cache(cache_path)
+        self.cache = None  # If you wish to train with EmbeddingCache, call self.create_embedding_cache(cache_path)
 
     def create_embedding_cache(self, cache_path):
         if cache_path is not None:

--- a/audiocraft/modules/jasco_conditioners.py
+++ b/audiocraft/modules/jasco_conditioners.py
@@ -88,12 +88,13 @@ class DrumsConditioner(WaveformConditioner):
         self._use_masking = False
         self.blurring_factor = blurring_factor
         self.seq_len = int(segment_duration * compression_model_framerate)
-        self.cache = None
-        # uncomment if you wish to train with EmbeddingCache.
-        # if cache_path is not None:
-        #     self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
-        #                                 compute_embed_fn=self._calc_coarse_drum_codes_for_cache,
-        #                                 extract_embed_fn=self._load_drum_codes_chunk)
+        self.cache = None # If you wish to train with EmbeddingCache, call self.create_embedding_cache(cache_path)
+
+    def create_embedding_cache(self, cache_path):
+        if cache_path is not None:
+            self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
+                                        compute_embed_fn=self._calc_coarse_drum_codes_for_cache,
+                                        extract_embed_fn=self._load_drum_codes_chunk)
 
     @torch.no_grad()
     def _get_drums_stem(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:

--- a/audiocraft/modules/jasco_conditioners.py
+++ b/audiocraft/modules/jasco_conditioners.py
@@ -89,10 +89,11 @@ class DrumsConditioner(WaveformConditioner):
         self.blurring_factor = blurring_factor
         self.seq_len = int(segment_duration * compression_model_framerate)
         self.cache = None
-        if cache_path is not None:
-            self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
-                                        compute_embed_fn=self._calc_coarse_drum_codes_for_cache,
-                                        extract_embed_fn=self._load_drum_codes_chunk)
+        # uncomment if you wish to train with EmbeddingCache.
+        # if cache_path is not None:
+        #     self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
+        #                                 compute_embed_fn=self._calc_coarse_drum_codes_for_cache,
+        #                                 extract_embed_fn=self._load_drum_codes_chunk)
 
     @torch.no_grad()
     def _get_drums_stem(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:


### PR DESCRIPTION
Comment out embedding cache, as released ckpt accidently contained a cache path which is not publically avalilable.